### PR TITLE
chore: allow duplicate product names across user groups

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -2527,10 +2527,6 @@ elseif ($datain == "systemsms") {
         sendmessage($from_id, $textbotlang['Admin']['adminphp']['err_name_must'], $backadmin, 'HTML');
         return;
     }
-    if (in_array($text, $name_product)) {
-        sendmessage($from_id, sprintf($textbotlang['Admin']['adminphp']['err_name_1'], $text), $backadmin, 'HTML');
-        return;
-    }
     savedata("clear", "name_product", $text);
     sendmessage($from_id, $textbotlang['Admin']['agent']['setAgentProduct'], $backadmin, 'HTML');
     step('get_agent', $from_id);
@@ -2538,6 +2534,13 @@ elseif ($datain == "systemsms") {
     $agent = ["n", "f", "n2"];
     if (!in_array($text, $agent)) {
         sendmessage($from_id, $textbotlang['Admin']['agent']['invalidValue'], $backadmin, 'HTML');
+        return;
+    }
+    $userdata = json_decode($user['Processing_value'], true);
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM product WHERE name_product = ? AND agent = ?");
+    $stmt->execute([$userdata['name_product'] ?? '', $text]);
+    if ((int) $stmt->fetchColumn() !== 0) {
+        sendmessage($from_id, sprintf($textbotlang['Admin']['adminphp']['err_name_1'], $userdata['name_product'] ?? ''), $backadmin, 'HTML');
         return;
     }
     savedata("save", "agent", $text);
@@ -2910,11 +2913,13 @@ elseif ($datain == "systemsms") {
         sendmessage($from_id, $textbotlang['Admin']['adminphp']['err_name_must'], $backadmin, 'HTML');
         return;
     }
-    if (in_array($text, $name_product)) {
+    $panel = select("marzban_panel", "*", "code_panel", $user['Processing_value_one'], "select");
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM product WHERE name_product = ? AND agent = ? AND id != ?");
+    $stmt->execute([$text, $user['Processing_value_tow'], $user['Processing_value']]);
+    if ((int) $stmt->fetchColumn() !== 0) {
         sendmessage($from_id, sprintf($textbotlang['Admin']['adminphp']['err_name_2'], $text), $backadmin, 'HTML');
         return;
     }
-    $panel = select("marzban_panel", "*", "code_panel", $user['Processing_value_one'], "select");
     $stmt = $pdo->prepare("UPDATE product SET name_product = :name_products WHERE id = :name_product AND (Location = :Location OR Location = '/all') AND agent = :agent");
     $stmt->bindParam(':name_products', $text);
     $stmt->bindParam(':name_product', $user['Processing_value']);

--- a/api/product.php
+++ b/api/product.php
@@ -231,8 +231,10 @@ switch ($data['actions'] ?? '') {
         if (!empty($missing_fields)) {
             sendJsonResponse(false, "Missing required fields: " . implode(', ', $missing_fields), []);
         }
-        $prodcut = select("product", "*", "name_product", $data['name'], "count");
-        if ($prodcut != 0) {
+        $agent = empty($data['agent']) ? "f" : $data['agent'];
+        $stmt = $pdo->prepare("SELECT COUNT(*) FROM product WHERE name_product = ? AND agent = ?");
+        $stmt->execute([$data['name'], $agent]);
+        if ((int) $stmt->fetchColumn() !== 0) {
             sendJsonResponse(false, "product name exits", [], 200);
         }
         $panel = select("marzban_panel", "*", "code_panel", $data['location'], "select");
@@ -292,8 +294,10 @@ switch ($data['actions'] ?? '') {
             sendJsonResponse(false, "product not found", [], 200);
         }
         if (isset($data['name']) && $product['name_product'] != $data['name']) {
-            $product_check = select("product", "*", "name_product", $data['name'], "count");
-            if ($product_check != 0)
+            $editAgent = isset($data['agent']) ? $data['agent'] : $product['agent'];
+            $stmt = $pdo->prepare("SELECT COUNT(*) FROM product WHERE name_product = ? AND agent = ? AND id != ?");
+            $stmt->execute([$data['name'], $editAgent, $data['id']]);
+            if ((int) $stmt->fetchColumn() !== 0)
                 sendJsonResponse(false, "product name exits", [], 200);
             update("invoice", "name_product", $data['name'], "name_product", $product['name_product']);
         }

--- a/panel/product.php
+++ b/panel/product.php
@@ -11,7 +11,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'add')
     header('Location: product.php');
     exit;
   }
-  if (db_count($pdo, "SELECT COUNT(*) FROM product WHERE name_product = ?", [$name])) {
+  if (db_count($pdo, "SELECT COUNT(*) FROM product WHERE name_product = ? AND agent = ?", [$name, $_POST['agent_product'] ?? 'f'])) {
     flash('error', $textbotlang['panel']['productNameExists']);
     header('Location: product.php');
     exit;
@@ -36,6 +36,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'edit'
   $pid = (int) ($_POST['edit_id'] ?? 0);
   $name = trim($_POST['name_product'] ?? '');
   if ($pid && $name !== '') {
+    $agent = $_POST['agent_product'] ?? 'f';
+    if (db_count($pdo, "SELECT COUNT(*) FROM product WHERE name_product = ? AND agent = ? AND id != ?", [$name, $agent, $pid])) {
+      flash('error', $textbotlang['panel']['productNameExists']);
+      header('Location: product.php');
+      exit;
+    }
     try {
       db_query(
         $pdo,


### PR DESCRIPTION
## Summary
- Change product name uniqueness from global `name_product` to `(name_product, agent)`, so admins can create the same product name (e.g. `1GB`) separately for groups `f`, `n`, and `n2`.

## Changes
**Product uniqueness**
- `panel/product.php` — validate name per agent on add/edit
- `api/product.php` — same for `product_add` / `product_edit`
- `admin.php` — move bot-admin name check to after group selection; validate rename per agent

## Test plan
- [x] Add product `1GB` for group `f`, then add `1GB` for `n` and `n2` via web panel and Telegram admin
- [x] Verify duplicate `1GB` within the same group is still rejected
- [x] Confirm existing purchases still work (products selected by `code_product`)