### PR TITLE
fix: harden error handling and restore service delivery after QR/temp write failures

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -10118,7 +10118,10 @@ if ($datain == "settimecornday" && $adminrulecheck['rule'] == "administrator") {
     step("home", $from_id);
 } elseif ($user['step'] == "getpanelhidebotsaz") {
     $userdata = json_decode($user['Processing_value'], true);
-    $list_panel = json_decode(select("botsaz", "hide_panel", "id_user", $userdata['id_user'], "select")['hide_panel'], true);
+    $list_panel = json_decode(select("botsaz", "hide_panel", "id_user", $userdata['id_user'], "select")['hide_panel'] ?? '[]', true);
+    if (!is_array($list_panel)) {
+        $list_panel = [];
+    }
     if (in_array($text, $list_panel)) {
         sendmessage($from_id, $textbotlang['Admin']['managepanel']['alreadyAdded'], null, 'HTML');
         return;
@@ -10130,7 +10133,10 @@ if ($datain == "settimecornday" && $adminrulecheck['rule'] == "administrator") {
     global $list_hide_panel;
     $id_user = $datagetr[1];
     savedata("clear", "id_user", $id_user);
-    $list_panel = json_decode(select("botsaz", "hide_panel", "id_user", $id_user, "select")['hide_panel'], true);
+    $list_panel = json_decode(select("botsaz", "hide_panel", "id_user", $id_user, "select")['hide_panel'] ?? '[]', true);
+    if (!is_array($list_panel)) {
+        $list_panel = [];
+    }
     $list_hide_panel = [
         'keyboard' => [],
         'resize_keyboard' => true,
@@ -10151,7 +10157,10 @@ if ($datain == "settimecornday" && $adminrulecheck['rule'] == "administrator") {
     step("home", $from_id);
 } elseif ($user['step'] == "getremovehidepanel") {
     $userdata = json_decode($user['Processing_value'], true);
-    $list_panel = json_decode(select("botsaz", "hide_panel", "id_user", $userdata['id_user'], "select")['hide_panel'], true);
+    $list_panel = json_decode(select("botsaz", "hide_panel", "id_user", $userdata['id_user'], "select")['hide_panel'] ?? '[]', true);
+    if (!is_array($list_panel)) {
+        $list_panel = [];
+    }
     if (!in_array($text, $list_panel)) {
         sendmessage($from_id, $textbotlang['Admin']['managepanel']['panelNotInList'], null, 'HTML');
         return;

--- a/botapi.php
+++ b/botapi.php
@@ -54,7 +54,13 @@ function telegram($method, $datas = [], $token = null)
     }
 
     if (isset($decodedResponse['ok']) && !$decodedResponse['ok']) {
-        error_log(json_encode($decodedResponse));
+        $errorCode = $decodedResponse['error_code'] ?? 0;
+        $description = $decodedResponse['description'] ?? '';
+        $silent = $errorCode === 403
+            || ($errorCode === 400 && str_contains($description, 'message is not modified'));
+        if (!$silent) {
+            error_log(json_encode($decodedResponse));
+        }
     }
 
     return $decodedResponse;

--- a/function.php
+++ b/function.php
@@ -530,13 +530,20 @@ function rate_arze()
 {
     $arze_rate = [];
     $requests_tron = json_decode(file_get_contents('https://api.diadata.org/v1/assetQuotation/Tron/0x0000000000000000000000000000000000000000'), true);
-    $html_read = file_get_contents("https://www.bon-bast.com/");
-    preg_match('/<span>\s*([\d,]+)\s*<\/span>/', $html_read, $matches);
-    if (!empty($matches[1])) {
-        $requestsusd = str_replace(',', '', $matches[1]);
+    $requestsusd = 0;
+    $html_read = @file_get_contents("https://www.bon-bast.com/");
+    if ($html_read !== false) {
+        preg_match('/<span>\s*([\d,]+)\s*<\/span>/', $html_read, $matches);
+        if (!empty($matches[1])) {
+            $requestsusd = intval(str_replace(',', '', $matches[1]));
+        }
     }
-    $arze_rate['USD'] = intval($requestsusd);
-    $arze_rate['TRX'] = intval($requests_tron['Price'] * $arze_rate['USD']);
+    if ($requestsusd === 0) {
+        error_log('rate_arze: failed to fetch USD rate from bon-bast.com');
+        return null;
+    }
+    $arze_rate['USD'] = $requestsusd;
+    $arze_rate['TRX'] = intval(($requests_tron['Price'] ?? 0) * $arze_rate['USD']);
 
     return $arze_rate;
 }
@@ -1696,6 +1703,7 @@ function generateAuthStr($length = 10)
 }
 function createqrcode($contents)
 {
+    $contents = mb_convert_encoding((string)$contents, 'UTF-8', 'UTF-8');
     $builder = new Builder(
         writer: new PngWriter(),
         writerOptions: [],
@@ -1706,7 +1714,12 @@ function createqrcode($contents)
         margin: 10,
     );
 
-    $result = $builder->build();
+    try {
+        $result = $builder->build();
+    } catch (\Throwable $e) {
+        error_log('createqrcode failed: ' . $e->getMessage());
+        return null;
+    }
     return $result;
 }
 function sanitize_recursive(array $data): array

--- a/function.php
+++ b/function.php
@@ -1402,7 +1402,10 @@ function addBackgroundImage($urlimage, $qrCodeResult, $backgroundPath)
 
     imagecopy($backgroundImage, $qrCodeImage, $x, $y, 0, 0, $qrCodeWidth, $qrCodeHeight);
 
-    imagepng($backgroundImage, $urlimage);
+    if (!@imagepng($backgroundImage, $urlimage)) {
+        error_log("addBackgroundImage: Failed to write image to $urlimage");
+        @file_put_contents($urlimage, $qrString);
+    }
 
     imagedestroy($qrCodeImage);
     imagedestroy($backgroundImage);
@@ -1703,7 +1706,16 @@ function generateAuthStr($length = 10)
 }
 function createqrcode($contents)
 {
-    $contents = mb_convert_encoding((string)$contents, 'UTF-8', 'UTF-8');
+    $contents = (string) $contents;
+    if ($contents === '') {
+        return null;
+    }
+    if (!mb_check_encoding($contents, 'UTF-8')) {
+        $contents = mb_convert_encoding($contents, 'UTF-8', 'UTF-8');
+        if ($contents === false || $contents === '') {
+            return null;
+        }
+    }
     $builder = new Builder(
         writer: new PngWriter(),
         writerOptions: [],
@@ -1715,12 +1727,19 @@ function createqrcode($contents)
     );
 
     try {
-        $result = $builder->build();
+        return $builder->build();
     } catch (\Throwable $e) {
         error_log('createqrcode failed: ' . $e->getMessage());
         return null;
     }
-    return $result;
+}
+function qrTempPath($filename)
+{
+    $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'mirzabot_qr';
+    if (!is_dir($dir) && !@mkdir($dir, 0775, true) && !is_dir($dir)) {
+        $dir = sys_get_temp_dir();
+    }
+    return rtrim($dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($filename, DIRECTORY_SEPARATOR);
 }
 function sanitize_recursive(array $data): array
 {
@@ -1802,29 +1821,38 @@ function sendMessageService($panel_info, $config, $sub_link, $username_service, 
     }
     if ($STATUS_SEND_MESSAGE_PHOTO) {
         if ($panel_info['type'] == "WGDashboard") {
-            $urlimage = "{$panel_info['inboundid']}_{$invoice_id}.conf";
-            file_put_contents($urlimage, $sub_link);
-            telegram('senddocument', [
-                'chat_id' => $user_id,
-                'document' => new CURLFile($urlimage),
-                'reply_markup' => $reply_markup,
-                'caption' => $caption,
-                'parse_mode' => "HTML",
-            ]);
-            unlink($urlimage);
+            $urlimage = qrTempPath("{$panel_info['inboundid']}_{$invoice_id}.conf");
+            if (@file_put_contents($urlimage, $sub_link) === false) {
+                sendmessage($user_id, $caption, $reply_markup, 'HTML');
+            } else {
+                telegram('senddocument', [
+                    'chat_id' => $user_id,
+                    'document' => new CURLFile($urlimage),
+                    'reply_markup' => $reply_markup,
+                    'caption' => $caption,
+                    'parse_mode' => "HTML",
+                ]);
+                @unlink($urlimage);
+            }
         } else {
-            $urlimage = "$user_id$invoice_id.png";
+            $urlimage = qrTempPath("$user_id$invoice_id.png");
             $qrCode = createqrcode($out_put_qrcode);
-            file_put_contents($urlimage, $qrCode->getString());
-            addBackgroundImage($urlimage, $qrCode, $image);
-            telegram('sendphoto', [
-                'chat_id' => $user_id,
-                'photo' => new CURLFile($urlimage),
-                'reply_markup' => $reply_markup,
-                'caption' => $caption,
-                'parse_mode' => "HTML",
-            ]);
-            unlink($urlimage);
+            $photoSent = false;
+            if ($qrCode !== null && @file_put_contents($urlimage, $qrCode->getString()) !== false) {
+                addBackgroundImage($urlimage, $qrCode, $image);
+                $response = telegram('sendphoto', [
+                    'chat_id' => $user_id,
+                    'photo' => new CURLFile($urlimage),
+                    'reply_markup' => $reply_markup,
+                    'caption' => $caption,
+                    'parse_mode' => "HTML",
+                ]);
+                $photoSent = is_array($response) && !empty($response['ok']);
+                @unlink($urlimage);
+            }
+            if (!$photoSent) {
+                sendmessage($user_id, $caption, $reply_markup, 'HTML');
+            }
         }
     } else {
         sendmessage($user_id, $caption, $reply_markup, 'HTML');

--- a/index.php
+++ b/index.php
@@ -4073,7 +4073,7 @@ if ($user['step'] == "createusertest" || preg_match('/locationtest_(.*)/', $data
         ]
     ]);
     $timejalali = jdate('Y/m/d H:i:s');
-    $text_report = sprintf($textbotlang['Admin']['reportgroup']['accountCreated'], $textonebuy, $from_id, $username, $username_ac, $first_name, $userdate['name_panel'], $info_product['name_product'], $info_product['Service_time'], $info_product['Volume_constraint'], $balanceformatsellbefore, $balanceformatsell, $randomString, $user['agent'], $user['number'], $info_product['category'], $info_product['price_product'], $priceproduct, $timejalali);
+    $text_report = sprintf($textbotlang['Admin']['reportgroup']['accountCreated'], $textonebuy, $from_id, $username, $username_ac, $first_name, $userdate['name_panel'], $info_product['name_product'], $info_product['Service_time'], $info_product['Volume_constraint'], $balanceformatsellbefore, $balanceformatsell, $randomString, $user['agent'], $user['number'], $info_product['category'] ?? '', $info_product['price_product'], $priceproduct, $timejalali);
     if (strlen($setting['Channel_Report']) > 0) {
         telegram('sendmessage', [
             'chat_id' => $setting['Channel_Report'],

--- a/index.php
+++ b/index.php
@@ -791,6 +791,11 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
         return;
     }
     $nameloc = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$nameloc) {
+        sendmessage($from_id, $textbotlang['users']['status']['infoUnavailable'], $keyboard, 'html');
+        step('home', $from_id);
+        return;
+    }
     $username = $nameloc['id_invoice'];
     if (!in_array($nameloc['Status'], ['active', 'end_of_time', 'end_of_volume', 'sendedwarn', 'send_on_hold'])) {
         sendmessage($from_id, $textbotlang['users']['status']['infoUnavailable'], $keyboard, 'html');
@@ -1256,6 +1261,10 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
             $randomString = bin2hex(random_bytes(3));
             $urlimage = "$from_id$randomString.png";
             $qrCode = createqrcode($DataUserOut['links'][$i]);
+            if ($qrCode === null) {
+                sendmessage($from_id, "<code>{$DataUserOut['links'][$i]}</code>", null, 'HTML');
+                continue;
+            }
             file_put_contents($urlimage, $qrCode->getString());
             addBackgroundImage($urlimage, $qrCode, 'images.jpg');
             telegram('sendphoto', [
@@ -1271,6 +1280,10 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
     $randomString = bin2hex(random_bytes(3));
     $urlimage = "$from_id$randomString.png";
     $qrCode = createqrcode($DataUserOut['links'][$dataget[2]]);
+    if ($qrCode === null) {
+        sendmessage($from_id, "<code>{$DataUserOut['links'][$dataget[2]]}</code>", null, 'HTML');
+        return;
+    }
     file_put_contents($urlimage, $qrCode->getString());
     addBackgroundImage($urlimage, $qrCode, 'images.jpg');
     telegram('sendphoto', [
@@ -3060,8 +3073,13 @@ if ($user['step'] == "createusertest" || preg_match('/locationtest_(.*)/', $data
             sendmessage($from_id, $textbotlang['users']['selectoption'], $json_list_help, 'HTML');
         }
     }
-} elseif (preg_match('/^helpctgoryـ(.*)/', $datain, $dataget)) {
-    $helplist = select("help", "*", "category", $dataget[1], "fetchAll");
+} elseif (preg_match('/^helpctg_([0-9a-f]+)/', $datain, $dataget) || preg_match('/^helpctgoryـ(.*)/', $datain, $dataget)) {
+    if (isset($helpCategoryMap) && isset($helpCategoryMap[$dataget[1]])) {
+        $helpCategoryName = $helpCategoryMap[$dataget[1]];
+    } else {
+        $helpCategoryName = $dataget[1];
+    }
+    $helplist = select("help", "*", "category", $helpCategoryName, "fetchAll");
     $helpidos = ['inline_keyboard' => []];
     foreach ($helplist as $result) {
         $helpidos['inline_keyboard'][] = [
@@ -3834,7 +3852,7 @@ if ($user['step'] == "createusertest" || preg_match('/locationtest_(.*)/', $data
     ));
     $stmt = $pdo->prepare("INSERT IGNORE INTO invoice (id_user, id_invoice, username,time_sell, Service_location, name_product, price_product, Volume, Service_time,Status,note,refral,notifctions) VALUES (?,  ?, ?, ?, ?, ?, ?,?,?,?,?,?,?)");
     $Status = "unpaid";
-    $stmt->execute([$from_id, $randomString, $username_ac, $date, $marzban_list_get['name_panel'], $info_product['name_product'], $priceproduct, $info_product['Volume_constraint'], $info_product['Service_time'], $Status, $userdate['nameconfig'], $user['affiliates'], $notifctions]);
+    $stmt->execute([$from_id, $randomString, $username_ac, $date, $marzban_list_get['name_panel'], $info_product['name_product'], $priceproduct, $info_product['Volume_constraint'], $info_product['Service_time'], $Status, $userdate['nameconfig'] ?? null, $user['affiliates'], $notifctions]);
     if ($priceproduct > $user['Balance'] && $user['agent'] != "n2" && intval($priceproduct) != 0) {
         $marzbandirectpay = select("shopSetting", "*", "Namevalue", "statusdirectpabuy", "select")['value'];
         $Balance_prim = $priceproduct - $user['Balance'];
@@ -4923,7 +4941,7 @@ if ($user['step'] == "createusertest" || preg_match('/locationtest_(.*)/', $data
         updatePaymentMessageId($message_id, $randomString);
     } elseif ($datain == "iranpay1") {
         $rates = rate_arze();
-        if ($rates === null) {
+        if ($rates === null || empty($rates['TRX']) || empty($rates['USD'])) {
             sendmessage($from_id, $textbotlang['users']['Balance']['errorLinkPayment'], $keyboard, 'HTML');
             step('home', $from_id);
             return;
@@ -6479,7 +6497,12 @@ if (isset($update['message']['successful_payment'])) {
     update("user", "Processing_value", $location, "id", $from_id);
     $query = "SELECT * FROM product WHERE (Location = '$location' OR Location = '/all') AND agent= '{$user['agent']}'";
     $marzban_list_get = select("marzban_panel", "*", "code_panel", $location, "select");
-    $statuscustomvolume = json_decode($marzban_list_get['customvolume'], true)[$user['agent']];
+    if (empty($marzban_list_get)) {
+        sendmessage($from_id, $textbotlang['users']['status']['infoUnavailable'], null, 'HTML');
+        step('home', $from_id);
+        return;
+    }
+    $statuscustomvolume = json_decode($marzban_list_get['customvolume'] ?? '[]', true)[$user['agent']] ?? null;
     if ($marzban_list_get['MethodUsername'] == $textbotlang['users']['customusername'] || $marzban_list_get['MethodUsername'] == $textbotlang['keyboard']['customUsernameRandom']) {
         $datakeyboard = "prodcutservicesom_";
     } else {

--- a/index.php
+++ b/index.php
@@ -1157,7 +1157,7 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
         ]);
         update("user", "Processing_value", $nameloc['username'], "id", $from_id);
         $subscriptionurl = $DataUserOut['subscription_url'];
-        $urlimage = "{$marzban_list_get['inboundid']}_{$nameloc['username']}.conf";
+        $urlimage = qrTempPath("{$marzban_list_get['inboundid']}_{$nameloc['username']}.conf");
         file_put_contents($urlimage, $subscriptionurl);
         telegram('senddocument', [
             'chat_id' => $from_id,
@@ -1182,9 +1182,12 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
         update("user", "Processing_value", $nameloc['username'], "id", $from_id);
         $subscriptionurl = $DataUserOut['subscription_url'];
         $randomString = bin2hex(random_bytes(3));
-        $urlimage = "$from_id$randomString.png";
+        $urlimage = qrTempPath("$from_id$randomString.png");
         $qrCode = createqrcode($subscriptionurl);
-        file_put_contents($urlimage, $qrCode->getString());
+        if ($qrCode === null || @file_put_contents($urlimage, $qrCode->getString()) === false) {
+            sendmessage($from_id, $textsub, $bakinfos, 'HTML');
+            return;
+        }
         addBackgroundImage($urlimage, $qrCode, 'images.jpg');
         telegram('sendphoto', [
             'chat_id' => $from_id,
@@ -1193,7 +1196,7 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
             'caption' => $textsub,
             'parse_mode' => "HTML",
         ]);
-        unlink($urlimage);
+        @unlink($urlimage);
     }
 } elseif (preg_match('/removeauto-(\w+)/', $datain, $dataget)) {
     $id_invoice = $dataget[1];
@@ -1259,13 +1262,12 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
     if ($dataget[2] == "1520") {
         for ($i = 0; $i < count($DataUserOut['links']); ++$i) {
             $randomString = bin2hex(random_bytes(3));
-            $urlimage = "$from_id$randomString.png";
+            $urlimage = qrTempPath("$from_id$randomString.png");
             $qrCode = createqrcode($DataUserOut['links'][$i]);
-            if ($qrCode === null) {
+            if ($qrCode === null || @file_put_contents($urlimage, $qrCode->getString()) === false) {
                 sendmessage($from_id, "<code>{$DataUserOut['links'][$i]}</code>", null, 'HTML');
                 continue;
             }
-            file_put_contents($urlimage, $qrCode->getString());
             addBackgroundImage($urlimage, $qrCode, 'images.jpg');
             telegram('sendphoto', [
                 'chat_id' => $from_id,
@@ -1273,18 +1275,17 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
                 'caption' => "<code>{$DataUserOut['links'][$i]}</code>",
                 'parse_mode' => "HTML",
             ]);
-            unlink($urlimage);
+            @unlink($urlimage);
         }
         return;
     }
     $randomString = bin2hex(random_bytes(3));
-    $urlimage = "$from_id$randomString.png";
+    $urlimage = qrTempPath("$from_id$randomString.png");
     $qrCode = createqrcode($DataUserOut['links'][$dataget[2]]);
-    if ($qrCode === null) {
+    if ($qrCode === null || @file_put_contents($urlimage, $qrCode->getString()) === false) {
         sendmessage($from_id, "<code>{$DataUserOut['links'][$dataget[2]]}</code>", null, 'HTML');
         return;
     }
-    file_put_contents($urlimage, $qrCode->getString());
     addBackgroundImage($urlimage, $qrCode, 'images.jpg');
     telegram('sendphoto', [
         'chat_id' => $from_id,
@@ -1292,7 +1293,7 @@ if ($text == "/start" || $datain == "start" || $text == "start") {
         'caption' => "<code>{$DataUserOut['links'][$dataget[2]]}</code>",
         'parse_mode' => "HTML",
     ]);
-    unlink($urlimage);
+    @unlink($urlimage);
 } elseif (preg_match('/changestatus_(\w+)/', $datain, $dataget)) {
     $statuschangeservice = select("shopSetting", "*", "Namevalue", "statuschangeservice", "select")['value'];
     if ($statuschangeservice == "offstatus") {
@@ -3758,7 +3759,7 @@ if ($user['step'] == "createusertest" || preg_match('/locationtest_(.*)/', $data
         '{username}' => $username_ac,
         '{name_product}' => $info_product['name_product'],
         '{Service_time}' => $info_product['Service_time'],
-        '{note}' => $info_product['note'],
+        '{note}' => $info_product['note'] ?? '',
         '{price}' => $info_product_price_product,
         '{Volume}' => $info_product['Volume_constraint'],
         '{userBalance}' => $userBalance

--- a/keyboard.php
+++ b/keyboard.php
@@ -557,14 +557,17 @@ $stmt = $pdo->prepare("SELECT * FROM help");
 $stmt->execute();
 $helpcwtgory = ['inline_keyboard' => []];
 $datahelp = [];
+$helpCategoryMap = [];
 while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
     if (in_array($result['category'], $datahelp))
         continue;
     if ($result['category'] == null)
         continue;
     $datahelp[] = $result['category'];
+    $catId = dechex(crc32($result['category']));
+    $helpCategoryMap[$catId] = $result['category'];
     $helpcwtgory['inline_keyboard'][] = [
-        ['text' => $result['category'], 'callback_data' => "helpctgoryـ{$result['category']}"]
+        ['text' => $result['category'], 'callback_data' => "helpctg_{$catId}"]
     ];
 }
 if ($setting['linkappstatus'] == "1") {
@@ -1623,16 +1626,15 @@ function keyboard_config($config_split, $id_invoice, $back_active = true)
         $config = $config_split[$i];
         $split_config = explode("://", $config);
         $type_prtocol = $split_config[0];
-        $split_config = $split_config[1];
+        $split_config = $split_config[1] ?? '';
         if (isBase64($split_config)) {
             $split_config = base64_decode($split_config);
         }
         if ($type_prtocol == "vmess") {
-            $split_config = json_decode($split_config, true)['ps'];
-        } elseif ($type_prtocol == "ss") {
-            $split_config = explode("#", $split_config)[1];
+            $split_config = json_decode($split_config, true)['ps'] ?? '';
         } else {
-            $split_config = explode("#", $split_config)[1];
+            $parts = explode("#", $split_config);
+            $split_config = $parts[1] ?? $parts[0];
         }
         $keyboard_config['inline_keyboard'][] = [
             ['text' => $textbotlang['keyboard']['getConfig'], 'callback_data' => "configget_{$id_invoice}_$i"],

--- a/panels.php
+++ b/panels.php
@@ -90,9 +90,9 @@ class ManagePanel
                 if ($Get_Data_Panel['version_panel'] == "1") {
                     $out_put_link = outputlink($data_Output['subscription_url']);
                     if (isBase64($out_put_link)) {
-                        $data_Output['links'] = base64_decode(string: outputlink($data_Output['subscription_url']));
+                        $data_Output['links'] = base64_decode(string: $out_put_link);
                     }
-                    $data_Output['links'] = explode("\n", $data_Output['links']);
+                    $data_Output['links'] = explode("\n", $data_Output['links'] ?? '');
                 }
                 if ($invoice != false) {
                     $data_Output['subscription_url'] = "https://$domainhosts/sub/" . $invoice['id_invoice'];

--- a/panels.php
+++ b/panels.php
@@ -92,7 +92,7 @@ class ManagePanel
                     if (isBase64($out_put_link)) {
                         $data_Output['links'] = base64_decode(string: $out_put_link);
                     }
-                    $data_Output['links'] = explode("\n", $data_Output['links'] ?? '');
+                    $data_Output['links'] = explode("\n", $data_Output['links'] ?? []);
                 }
                 if ($invoice != false) {
                     $data_Output['subscription_url'] = "https://$domainhosts/sub/" . $invoice['id_invoice'];


### PR DESCRIPTION
## Summary
- Suppress expected Telegram API noise (403 blocked/kicked, 400 message-not-modified) from `error_log`
- Harden `rate_arze()` so bon-bast failures no longer cause undefined vars / division-by-zero
- Guard null/false DB results and optional keys (`nameconfig`, `note`, `category`, `hide_panel`, `links`, invoice fetch, panel lookup)
- Fix tutorial category buttons exceeding Telegram’s 64-byte `callback_data` limit (`BUTTON_DATA_INVALID`)
- Write QR/temp files to a writable temp dir and fall back to text config when photo send fails (fixes missing config after test/buy/admin approve)
- Safer config keyboard parsing when protocol/`#` fragments are missing

## Test plan
- [x] Request a test account → user gets config (photo or text), group still gets created log
- [x] Buy a service → after “در حال ساختن…” user gets config, not only “یک گزینه را انتخاب کنید”
- [x] Admin approve card payment for a pending service → user receives config + confirmation
- [x] Open آموزش‌ها with long Persian category names → buttons work (no `BUTTON_DATA_INVALID`)
- [x] Trigger iranpay/USD rate path when bon-bast is down → friendly payment error, no fatal
- [x] Confirm blocked-user / “message is not modified” responses no longer flood `error_log`
- [x] Buy product without `category` → report group message still sends, no undefined-key warning