### PR TITLE
fix: prevent empty chat_id from reaching Telegram API

### DIFF
--- a/botapi.php
+++ b/botapi.php
@@ -1,11 +1,35 @@
 <?php
 require_once 'config.php';
+function isTelegramChatIdEmpty($chat_id): bool
+{
+    if ($chat_id === null || $chat_id === false) {
+        return true;
+    }
+    if (is_array($chat_id) || is_object($chat_id)) {
+        return true;
+    }
+    $chat_id = trim((string) $chat_id);
+    if ($chat_id === '') {
+        return true;
+    }
+    return is_numeric($chat_id) && (int) $chat_id === 0;
+}
 function telegram($method, $datas = [], $token = null)
 {
     global $APIKEY;
 
     $token = $token === null ? $APIKEY : $token;
     $url = "https://api.telegram.org/bot" . $token . "/" . $method;
+
+    foreach (['chat_id', 'from_chat_id'] as $chatIdKey) {
+        if (array_key_exists($chatIdKey, $datas) && isTelegramChatIdEmpty($datas[$chatIdKey])) {
+            return [
+                'ok' => false,
+                'error_code' => 400,
+                'description' => 'Bad Request: chat_id is empty'
+            ];
+        }
+    }
 
     if (isset($datas['message_thread_id']) && intval($datas['message_thread_id']) <= 0) {
         unset($datas['message_thread_id']);
@@ -57,7 +81,12 @@ function telegram($method, $datas = [], $token = null)
         $errorCode = $decodedResponse['error_code'] ?? 0;
         $description = $decodedResponse['description'] ?? '';
         $silent = $errorCode === 403
-            || ($errorCode === 400 && str_contains($description, 'message is not modified'));
+            || ($errorCode === 400 && (
+                str_contains($description, 'message is not modified')
+                || str_contains($description, "message can't be deleted")
+                || str_contains($description, 'message to delete not found')
+                || str_contains($description, 'chat not found')
+            ));
         if (!$silent) {
             error_log(json_encode($decodedResponse));
         }
@@ -66,7 +95,9 @@ function telegram($method, $datas = [], $token = null)
     return $decodedResponse;
 }
 function sendmessage($chat_id,$text,$keyboard,$parse_mode,$bot_token = null){
-    if(intval($chat_id) == 0)return ['ok' => false];
+    if (isTelegramChatIdEmpty($chat_id)) {
+        return ['ok' => false];
+    }
     return telegram('sendmessage',[
         'chat_id' => $chat_id,
         'text' => $text,

--- a/cronbot/backupbot.php
+++ b/cronbot/backupbot.php
@@ -7,9 +7,10 @@ require_once '../botapi.php';
 $reportbackup = select("topicid", "idreport", "report", "backupfile", "select")['idreport'];
 $destination = getcwd();
 $setting = select("setting", "*");
+$canSendReport = !isTelegramChatIdEmpty($setting['Channel_Report'] ?? '');
 $sourcefir = dirname($destination);
 $botlist = select("botsaz", "*", null, null, "fetchAll");
-if ($botlist) {
+if ($botlist && $canSendReport) {
     foreach ($botlist as $bot) {
         $folderName = $bot['id_user'] . $bot['username'];
         shell_exec("zip -r $destination/file.zip $sourcefir/vpnbot/$folderName/data $sourcefir/vpnbot/$folderName/product.json $sourcefir/vpnbot/$folderName/product_name.json");
@@ -32,17 +33,21 @@ $output = [];
 $return_var = 0;
 exec($command, $output, $return_var);
 if ($return_var !== 0) {
-    telegram('sendmessage', [
-        'chat_id' => $setting['Channel_Report'],
-        'message_thread_id' => $reportbackup,
-        'text' => $textbotlang['keyboard']['backupError'],
-    ]);
+    if ($canSendReport) {
+        telegram('sendmessage', [
+            'chat_id' => $setting['Channel_Report'],
+            'message_thread_id' => $reportbackup,
+            'text' => $textbotlang['keyboard']['backupError'],
+        ]);
+    }
 } else {
-    telegram('sendDocument', [
-        'chat_id' => $setting['Channel_Report'],
-        'message_thread_id' => $reportbackup,
-        'document' => new CURLFile($backup_file_name),
-        'caption' => $textbotlang['Admin']['report']['backupCaption'],
-    ]);
+    if ($canSendReport) {
+        telegram('sendDocument', [
+            'chat_id' => $setting['Channel_Report'],
+            'message_thread_id' => $reportbackup,
+            'document' => new CURLFile($backup_file_name),
+            'caption' => $textbotlang['Admin']['report']['backupCaption'],
+        ]);
+    }
     unlink($backup_file_name);
 }

--- a/cronbot/lottery.php
+++ b/cronbot/lottery.php
@@ -70,7 +70,7 @@ if (intval($setting['scorestatus']) == 1) {
             $count++;
         }
 
-        if ($count > 0) {
+        if ($count > 0 && !isTelegramChatIdEmpty($setting['Channel_Report'] ?? '')) {
             telegram('sendmessage', [
                 'chat_id' => $setting['Channel_Report'],
                 'message_thread_id' => $otherreport,

--- a/function.php
+++ b/function.php
@@ -663,6 +663,9 @@ function channel(array $id_channel)
     global $from_id;
     $channel_link = array();
     foreach ($id_channel as $channel) {
+        if (isTelegramChatIdEmpty($channel)) {
+            continue;
+        }
         $response = telegram('getChatMember', [
             'chat_id' => $channel,
             'user_id' => $from_id
@@ -1031,7 +1034,9 @@ function DirectPayment($order_id, $image = 'images.jpg')
         if ($Payment_report['Payment_Method'] == "cart to cart" or $Payment_report['Payment_Method'] == "arze digital offline") {
             update("invoice", "Status", "active", "id_invoice", $get_invoice['id_invoice']);
             $textconfrom = sprintf($textbotlang['Admin']['reportgroup']['paymentConfirmedService'], $username_ac, $get_invoice['Service_location'], $Balance_id['id'], $Payment_report['id_order'], $Balance_id['username'], $Balance_id['Balance'], $format_price_cart, $Payment_report['dec_not_confirmed']);
-            Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            if (!isTelegramChatIdEmpty($from_id) && intval($message_id) != 0) {
+                Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            }
         }
     } elseif ($steppay[0] == "getextenduser") {
         $balanceformatsell = number_format(select("user", "Balance", "id", $Balance_id['id'], "select")['Balance'], 0);
@@ -1155,7 +1160,9 @@ function DirectPayment($order_id, $image = 'images.jpg')
         if ($Payment_report['Payment_Method'] == "cart to cart" or $Payment_report['Payment_Method'] == "arze digital offline") {
 
             $textconfrom = sprintf($textbotlang['Admin']['reportgroup']['paymentConfirmedRenew'], $usernamepanel, $prodcut['name_product'], $nameloc['Service_location'], $Balance_id['id'], $Payment_report['id_order'], $Balance_id['username'], $Balance_id['Balance'], $format_price_cart, $Payment_report['dec_not_confirmed']);
-            Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            if (!isTelegramChatIdEmpty($from_id) && intval($message_id) != 0) {
+                Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            }
         }
     } elseif ($steppay[0] == "getextravolumeuser") {
         $steppay = explode("%", $steppay[1]);
@@ -1219,7 +1226,9 @@ function DirectPayment($order_id, $image = 'images.jpg')
         $volumes = $volume;
         if ($Payment_report['Payment_Method'] == "cart to cart") {
             $textconfrom = sprintf($textbotlang['Admin']['reportgroup']['paymentConfirmedExtraVolume'], $volumes, $steppay[0], $Balance_id['id'], $Payment_report['id_order'], $Balance_id['username'], $Balance_id['Balance'], $format_price_cart);
-            Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            if (!isTelegramChatIdEmpty($from_id) && intval($message_id) != 0) {
+                Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            }
         }
         update("invoice", "Status", "active", "id_invoice", $nameloc['id_invoice']);
         $text_report = sprintf($textbotlang['Admin']['reportgroup']['extraVolumeFn'], $Balance_id['id'], $volumes, $Payment_report['price'], $steppay[0], $Balance_id['Balance']);
@@ -1295,7 +1304,9 @@ function DirectPayment($order_id, $image = 'images.jpg')
         if ($Payment_report['Payment_Method'] == "cart to cart") {
             $volumes = $tmieextra;
             $textconfrom = sprintf($textbotlang['Admin']['reportgroup']['paymentConfirmedExtraTime'], $volumes, $steppay[0], $Balance_id['id'], $Payment_report['id_order'], $Balance_id['username'], $Balance_id['Balance'], $format_price_cart);
-            Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            if (!isTelegramChatIdEmpty($from_id) && intval($message_id) != 0) {
+                Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            }
         }
         update("invoice", "Status", "active", "id_invoice", $nameloc['id_invoice']);
         $text_report = sprintf($textbotlang['Admin']['reportgroup']['extraTimeFn'], $Balance_id['id'], $volumes, $Payment_report['price'], $steppay[0]);
@@ -1314,7 +1325,9 @@ function DirectPayment($order_id, $image = 'images.jpg')
         $format_price_cart = $Payment_report['price'];
         if ($Payment_report['Payment_Method'] == "cart to cart" or $Payment_report['Payment_Method'] == "arze digital offline") {
             $textconfrom = sprintf($textbotlang['Admin']['reportgroup']['newPaymentBalanceFn'], $Balance_id['id'], $Payment_report['id_order'], $Balance_id['username'], $format_price_cart, $Balance_id['Balance'], $Payment_report['dec_not_confirmed']);
-            Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            if (!isTelegramChatIdEmpty($from_id) && intval($message_id) != 0) {
+                Editmessagetext($from_id, $message_id, $textconfrom, $Confirm_pay);
+            }
         }
         sendmessage($Payment_report['id_user'], sprintf($textbotlang['users']['Balance']['chargedThanks'], $Payment_report['price'], $Payment_report['id_order']), null, 'HTML');
     }
@@ -1878,6 +1891,9 @@ function sendMessageService($panel_info, $config, $sub_link, $username_service, 
     if (!check_active_btn($setting['keyboardmain'], "text_help"))
         $reply_markup = null;
     $user_id = $user_id == null ? $from_id : $user_id;
+    if (isTelegramChatIdEmpty($user_id)) {
+        return;
+    }
     $STATUS_SEND_MESSAGE_PHOTO = $panel_info['config'] == "onconfig" && (is_array($config) ? count($config) : 0) != 1 ? false : true;
     $out_put_qrcode = "";
     if ($panel_info['type'] == "Manualsale" || $panel_info['type'] == "ibsng" || $panel_info['type'] == "mikrotik") {

--- a/vpnbot/Default/botapi.php
+++ b/vpnbot/Default/botapi.php
@@ -1,10 +1,33 @@
 <?php
 require_once 'config.php';
+function isTelegramChatIdEmpty($chat_id): bool
+{
+    if ($chat_id === null || $chat_id === false) {
+        return true;
+    }
+    if (is_array($chat_id) || is_object($chat_id)) {
+        return true;
+    }
+    $chat_id = trim((string) $chat_id);
+    if ($chat_id === '') {
+        return true;
+    }
+    return is_numeric($chat_id) && (int) $chat_id === 0;
+}
 function telegram($method, $datas = [],$botToken = null)
 {
     global $ApiToken;
     if($botToken != null){
         $ApiToken = $botToken;
+    }
+    foreach (['chat_id', 'from_chat_id'] as $chatIdKey) {
+        if (array_key_exists($chatIdKey, $datas) && isTelegramChatIdEmpty($datas[$chatIdKey])) {
+            return [
+                'ok' => false,
+                'error_code' => 400,
+                'description' => 'Bad Request: chat_id is empty'
+            ];
+        }
     }
     $url = "https://api.telegram.org/bot" . $ApiToken . "/" . $method;
     $ch = curl_init();
@@ -19,6 +42,9 @@ function telegram($method, $datas = [],$botToken = null)
     }
 }
 function sendmessage($chat_id,$text,$keyboard,$parse_mode){
+    if (isTelegramChatIdEmpty($chat_id)) {
+        return ['ok' => false];
+    }
     return telegram('sendmessage',[
         'chat_id' => $chat_id,
         'text' => $text,

--- a/vpnbot/Default/func.php
+++ b/vpnbot/Default/func.php
@@ -49,6 +49,9 @@ function DirectPaymentbot($order_id,$image = 'images.jpg'){
 }
 function channel_check($id_channel){
     global $from_id;
+        if (isTelegramChatIdEmpty($id_channel)) {
+            return [];
+        }
         $channel_link = array();
          $response = telegram('getChatMember',[
                 'chat_id' => $id_channel,

--- a/vpnbot/update/botapi.php
+++ b/vpnbot/update/botapi.php
@@ -1,10 +1,33 @@
 <?php
 require_once 'config.php';
+function isTelegramChatIdEmpty($chat_id): bool
+{
+    if ($chat_id === null || $chat_id === false) {
+        return true;
+    }
+    if (is_array($chat_id) || is_object($chat_id)) {
+        return true;
+    }
+    $chat_id = trim((string) $chat_id);
+    if ($chat_id === '') {
+        return true;
+    }
+    return is_numeric($chat_id) && (int) $chat_id === 0;
+}
 function telegram($method, $datas = [],$botToken = null)
 {
     global $ApiToken;
     if($botToken != null){
         $ApiToken = $botToken;
+    }
+    foreach (['chat_id', 'from_chat_id'] as $chatIdKey) {
+        if (array_key_exists($chatIdKey, $datas) && isTelegramChatIdEmpty($datas[$chatIdKey])) {
+            return [
+                'ok' => false,
+                'error_code' => 400,
+                'description' => 'Bad Request: chat_id is empty'
+            ];
+        }
     }
     $url = "https://api.telegram.org/bot" . $ApiToken . "/" . $method;
     $ch = curl_init();
@@ -19,6 +42,9 @@ function telegram($method, $datas = [],$botToken = null)
     }
 }
 function sendmessage($chat_id,$text,$keyboard,$parse_mode){
+    if (isTelegramChatIdEmpty($chat_id)) {
+        return ['ok' => false];
+    }
     return telegram('sendmessage',[
         'chat_id' => $chat_id,
         'text' => $text,

--- a/vpnbot/update/func.php
+++ b/vpnbot/update/func.php
@@ -48,6 +48,9 @@ function DirectPaymentbot($order_id, $image = 'images.jpg')
 function channel_check($id_channel)
 {
     global $from_id;
+    if (isTelegramChatIdEmpty($id_channel)) {
+        return [];
+    }
     $channel_link = array();
     $response = telegram('getChatMember', [
         'chat_id' => $id_channel,


### PR DESCRIPTION
## Summary

- Add `isTelegramChatIdEmpty()` guard inside `telegram()` so any call with a null/empty/zero `chat_id` returns early without hitting the API — eliminates the `[WARN] Telegram chat_id is empty` health alerts
- Silence additional noisy 400 errors (`message can't be deleted`, `message to delete not found`, `chat not found`) in `botapi.php`
- Guard `channel()` loop, `sendMessageService()`, and all `Editmessagetext()` calls inside `DirectPayment` that receive `$from_id = 0` from payment-gateway webhooks
- Skip Telegram sends in `backupbot.php` and `lottery.php` when `Channel_Report` is empty
- Apply same guard to `vpnbot/Default` and `vpnbot/update` botapi + func files

## Test plan

- [ ] Bot with no Channel_Report configured: no `[WARN] Telegram chat_id is empty` in health monitor
- [ ] Active bot with Channel_Report set: group reports still arrive normally
- [ ] Card-to-card payment confirmation: admin edit message still works when triggered from Telegram (from_id != 0)
- [ ] Payment gateway webhook (zarinpal/plisio/etc.): no crash, no WARN in logs